### PR TITLE
Добавлены ссылки на API сервера авторизации

### DIFF
--- a/src/main/java/ru/methuselah/authlib/links/LinksElyBy.java
+++ b/src/main/java/ru/methuselah/authlib/links/LinksElyBy.java
@@ -14,9 +14,9 @@ public final class LinksElyBy extends Links
 			"/session/hasJoined",
 			"/session/legacy/join",
 			"/session/legacy/hasJoined",
-			null,
-			null,
-			null,
+			"/api/users/profiles/minecraft/",
+			"/api/user/profiles/",
+			"/api/profiles/minecraft",
 			"/session/profile/");
 		super.setProvider(Links.LinksProvider.elyby);
 	}


### PR DESCRIPTION
Мы заимплементили альтернативу Mojang API для полноценной поддержки сервера авторизации.
Правда я не тестил поведение этого плагина в реальной ситуации по этим ссылкам, но API работает в соответствии со спецификациями Mojang, так что проблем быть не должно.
